### PR TITLE
[17.06.1] Make Linux memory allocations int64 not uint64

### DIFF
--- a/config-linux.md
+++ b/config-linux.md
@@ -283,17 +283,15 @@ For more information on how these two settings work together, see [the memory cg
 **`memory`** (object, OPTIONAL) represents the cgroup subsystem `memory` and it's used to set limits on the container's memory usage.
 For more information, see [the memory cgroup man page][cgroup-v1-memory].
 
-The following parameters can be specified to setup the controller:
+Values for memory specify the limit in bytes, or `-1` for unlimited memory.
 
-* **`limit`** *(uint64, OPTIONAL)* - sets limit of memory usage in bytes
+* **`limit`** *(int64, OPTIONAL)* - sets limit of memory usage
+* **`reservation`** *(int64, OPTIONAL)* - sets soft limit of memory usage
+* **`swap`** *(int64, OPTIONAL)* - sets limit of memory+Swap usage
+* **`kernel`** *(int64, OPTIONAL)* - sets hard limit for kernel memory
+* **`kernelTCP`** *(int64, OPTIONAL)* - sets hard limit for kernel TCP buffer memory
 
-* **`reservation`** *(uint64, OPTIONAL)* - sets soft limit of memory usage in bytes
-
-* **`swap`** *(uint64, OPTIONAL)* - sets limit of memory+Swap usage
-
-* **`kernel`** *(uint64, OPTIONAL)* - sets hard limit for kernel memory
-
-* **`kernelTCP`** *(uint64, OPTIONAL)* - sets hard limit in bytes for kernel TCP buffer memory
+For `swappiness` the values are from 0 to 100. Higher means more swappy.
 
 * **`swappiness`** *(uint64, OPTIONAL)* - sets swappiness parameter of vmscan (See sysctl's vm.swappiness)
 
@@ -304,8 +302,8 @@ The following parameters can be specified to setup the controller:
         "limit": 536870912,
         "reservation": 536870912,
         "swap": 536870912,
-        "kernel": 0,
-        "kernelTCP": 0,
+        "kernel": -1,
+        "kernelTCP": -1,
         "swappiness": 0
     }
 ```

--- a/config.md
+++ b/config.md
@@ -687,8 +687,8 @@ Here is a full example `config.json` for reference.
                 "limit": 536870912,
                 "reservation": 536870912,
                 "swap": 536870912,
-                "kernel": 0,
-                "kernelTCP": 0,
+                "kernel": -1,
+                "kernelTCP": -1,
                 "swappiness": 0
             },
             "cpu": {

--- a/schema/config-linux.json
+++ b/schema/config-linux.json
@@ -178,23 +178,23 @@
                         "properties": {
                             "kernel": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernel",
-                                "$ref": "defs.json#/definitions/uint64"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "kernelTCP": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/kernelTCP",
-                                "$ref": "defs.json#/definitions/uint64"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "limit": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/limit",
-                                "$ref": "defs.json#/definitions/uint64"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "reservation": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/reservation",
-                                "$ref": "defs.json#/definitions/uint64"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "swap": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swap",
-                                "$ref": "defs.json#/definitions/uint64"
+                                "$ref": "defs.json#/definitions/int64"
                             },
                             "swappiness": {
                                 "id": "https://opencontainers.org/schema/bundle/linux/resources/memory/swappiness",

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -281,16 +281,16 @@ type LinuxBlockIO struct {
 // LinuxMemory for Linux cgroup 'memory' resource management
 type LinuxMemory struct {
 	// Memory limit (in bytes).
-	Limit *uint64 `json:"limit,omitempty"`
+	Limit *int64 `json:"limit,omitempty"`
 	// Memory reservation or soft_limit (in bytes).
-	Reservation *uint64 `json:"reservation,omitempty"`
+	Reservation *int64 `json:"reservation,omitempty"`
 	// Total memory limit (memory + swap).
-	Swap *uint64 `json:"swap,omitempty"`
+	Swap *int64 `json:"swap,omitempty"`
 	// Kernel memory limit (in bytes).
-	Kernel *uint64 `json:"kernel,omitempty"`
+	Kernel *int64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
-	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
+	KernelTCP *int64 `json:"kernelTCP,omitempty"`
+	// How aggressive the kernel will swap memory pages.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
 


### PR DESCRIPTION
>The kernel ABI to these values is a string, which accepts the value `-1`
> to mean "unlimited" or an integer up to 2^63 for an amount of memory in
> bytes.
> 
> While the internal representation in the kernel is unsigned, this is not
> exposed in any ABI directly. Because of the user-kernel memory split, values
> over 2^63 are not really useful; indeed that much memory is not supported,
> as physical memory is limited to 52 bits in the forthcoming switch to five
> level page tables. So it is much more natural to support the value `-1` for
> unlimited, especially as the actual number needed to represent the maximum
> has varied in different kernel versions, and across 32 and 64 bit architectures,
> so determining the value to use is not possible, so it is necessary to write
> the string `-1` to the cgroup files.
>
> See also discussion in
> - https://github.com/opencontainers/runc/pull/1494
> - https://github.com/opencontainers/runc/pull/1492
> - https://github.com/opencontainers/runc/pull/1375
> - https://github.com/opencontainers/runc/issues/1421
>
> Signed-off-by: Justin Cormack <justin.cormack@docker.com>

(cherry picked from commit e73cd70caac6ec35ff8153847491352236632417)
Signed-off-by: Tibor Vass <tibor@docker.com>

From opencontainers/runtime-spec#876

cc @justincormack @crosbymichael 